### PR TITLE
fix: Apply filter: extra grouping removed

### DIFF
--- a/src/main/java/org/qubership/integration/platform/runtime/catalog/service/filter/ChainFilterSpecificationBuilder.java
+++ b/src/main/java/org/qubership/integration/platform/runtime/catalog/service/filter/ChainFilterSpecificationBuilder.java
@@ -130,11 +130,6 @@ public class ChainFilterSpecificationBuilder {
 
             Predicate orResult = null;
             if (!orFilters.isEmpty()) {
-                if (!searchMode) {
-                    Path<Integer> chainIdPath = root.get("id");
-                    query.groupBy(chainIdPath);
-                }
-
                 List<Predicate> orPredicates = new ArrayList<>();
 
                 for (Map.Entry<FilterFeature, List<FilterRequestDTO>> entry : orFilters.entrySet()) {


### PR DESCRIPTION
**Problem definition**
Extra grouping used in filtering chains query. It was removed since `distinct` applied at the upper level for chains

**Before**
![image](https://github.com/user-attachments/assets/9037a620-71e6-426b-99af-68803178867d)

**After**
![image](https://github.com/user-attachments/assets/f585e911-b9f4-4fb8-8d38-49d289694653)
