### PR TITLE
test: Fix service-call template tests for sendEmptyQueryParams feature

### DIFF
--- a/src/test/resources/testData/input/builder/templates/service_call_http.yml
+++ b/src/test/resources/testData/input/builder/templates/service_call_http.yml
@@ -198,6 +198,7 @@ elements:
       integrationSpecificationGroupId: "78a90c20-9d90-424c-a0a9-5b37de84933d"
       integrationOperationProtocolType: "http"
       integrationOperationPathParameters: {}
+      sendEmptyQueryParams: false
       propagateContext: true
     service-environment:
       id: "0c151b35-1a38-4032-af81-77d1385c2c04"

--- a/src/test/resources/testData/output/builder/templates/service_call_http.xml
+++ b/src/test/resources/testData/output/builder/templates/service_call_http.xml
@@ -19,6 +19,9 @@
         <setProperty name="serviceCallPath">
             <simple>/RestNotify_1</simple>
         </setProperty>
+        <setProperty name="serviceCallSendEmptyQueryParams">
+            <simple>false</simple>
+        </setProperty>
         <removeHeader name="CamelHttpQuery"/>
         <step id="Prepare request--8ff3584f-3666-4c75-ba40-a3c8955c44e8">
             <setProperty name="internalProperty_mappingConfig">
@@ -56,6 +59,7 @@
                     <constant>false</constant>
                 </setProperty>
                 <doTry id="Request--8ff3584f-3666-4c75-ba40-a3c8955c44e8">
+                    <process ref="queryParameterFilterProcessor"/>
                     <process ref="httpSenderProcessor"/>
                     <process ref="httpProducerCharsetProcessor"/>
                     <toD allowOptimisedComponents="false" uri="http:stub?httpClientConfigurer=#8ff3584f-3666-4c75-ba40-a3c8955c44e8&amp;followRedirects=true"/>
@@ -165,4 +169,5 @@
     <removeProperty name="serviceCallExchange"/>
     <removeProperty name="serviceCallService"/>
     <removeProperty name="serviceCallVariablesHeader"/>
+    <removeProperty name="serviceCallSendEmptyQueryParams"/>
 </route>

--- a/src/test/resources/testData/output/builder/templates/service_call_kafka.xml
+++ b/src/test/resources/testData/output/builder/templates/service_call_kafka.xml
@@ -169,4 +169,5 @@
     <removeProperty name="serviceCallExchange"/>
     <removeProperty name="serviceCallService"/>
     <removeProperty name="serviceCallVariablesHeader"/>
+    <removeProperty name="serviceCallSendEmptyQueryParams"/>
 </route>


### PR DESCRIPTION
test: Update service-call template test files for sendEmptyQueryParams feature

- Add sendEmptyQueryParams: false to HTTP service call test input data
- Add serviceCallSendEmptyQueryParams cleanup property to both HTTP and Kafka test files
- Add queryParameterFilterProcessor to HTTP service call test output