### PR TITLE
fix: <v0.2> Export swimlane IDs to prevent disappearance after import

### DIFF
--- a/src/main/java/org/qubership/integration/platform/runtime/catalog/service/exportimport/mapper/chain/ChainExternalEntityMapper.java
+++ b/src/main/java/org/qubership/integration/platform/runtime/catalog/service/exportimport/mapper/chain/ChainExternalEntityMapper.java
@@ -144,13 +144,11 @@ public class ChainExternalEntityMapper implements ExternalEntityMapper<Chain, Ch
                         .defaultSwimlaneId(
                                 Optional.ofNullable(chain.getDefaultSwimlane())
                                         .map(SwimlaneChainElement::getId)
-                                        .orElse(null)
-                        )
+                                        .orElse(null))
                         .reuseSwimlaneId(
                                 Optional.ofNullable(chain.getReuseSwimlane())
                                         .map(SwimlaneChainElement::getId)
-                                        .orElse(null)
-                        )
+                                        .orElse(null))
                         .elements(elementsExternalMapperEntity.getChainElementExternalEntities())
                         .dependencies(extractExternalDependencies(chain))
                         .migrations(chainImportFileMigrations.stream()


### PR DESCRIPTION
### Problem Description:
Swimlanes disappear after importing or deploying chains because defaultSwimlaneId and reuseSwimlaneId are not exported.
### Solution Description:
Added defaultSwimlaneId and reuseSwimlaneId to the export in ChainExternalEntityMapper.toExternalEntity().
### Changes:
Export defaultSwimlaneId and reuseSwimlaneId using Optional.ofNullable() pattern