### PR TITLE
fix: <v0.3> export swimlane IDs to prevent disappearance after import

### DIFF
--- a/src/main/java/org/qubership/integration/platform/runtime/catalog/service/exportimport/mapper/chain/ChainExternalEntityMapper.java
+++ b/src/main/java/org/qubership/integration/platform/runtime/catalog/service/exportimport/mapper/chain/ChainExternalEntityMapper.java
@@ -140,6 +140,14 @@ public class ChainExternalEntityMapper implements ExternalEntityMapper<Chain, Ch
                         .labels(chain.getLabels().stream().map(ChainLabel::getName).collect(Collectors.toList()))
                         .folder(createFolderExternalEntity(chain))
                         .maskedFields(createMaskedFieldExternalEntities(chain.getMaskedFields()))
+                        .defaultSwimlaneId(
+                                Optional.ofNullable(chain.getDefaultSwimlane())
+                                        .map(SwimlaneChainElement::getId)
+                                        .orElse(null))
+                        .reuseSwimlaneId(
+                                Optional.ofNullable(chain.getReuseSwimlane())
+                                        .map(SwimlaneChainElement::getId)
+                                        .orElse(null))
                         .elements(elementsExternalMapperEntity.getChainElementExternalEntities())
                         .dependencies(extractExternalDependencies(chain))
                         .migrations(chainImportFileMigrations.stream()


### PR DESCRIPTION
Add defaultSwimlaneId and reuseSwimlaneId to chain export to ensure swimlanes are properly restored after import/deploy operations.