### PR TITLE
fix: #405 Adjust json schema processor to work with oneOf anyOf allOf…

### DIFF
--- a/src/main/java/org/qubership/integration/platform/runtime/catalog/service/resolvers/CommonSchemaResolver.java
+++ b/src/main/java/org/qubership/integration/platform/runtime/catalog/service/resolvers/CommonSchemaResolver.java
@@ -48,8 +48,6 @@ public abstract class CommonSchemaResolver implements SchemaResolver {
     private static final String ARRAY_FIELD_TYPE = "array";
     private static final String EMPTY_REF = "#/";
     private static final String ADDITIONAL_PROPERTIES_FIELD_NAME = "additionalProperties";
-    private static final String ALL_OF_FIELD_NAME = "allOf";
-    private static final String ANY_OF_FIELD_NAME = "anyOf";
 
 
     @Override
@@ -108,6 +106,15 @@ public abstract class CommonSchemaResolver implements SchemaResolver {
 
                     JsonNode additionalPropertiesNode = schemaNode.get(ADDITIONAL_PROPERTIES_FIELD_NAME);
                     getSchemaNodeProperties(componentsNode, result, additionalPropertiesNode, modelType, refList);
+
+                    JsonNode allOfProperties = schemaNode.get(ALL_OF);
+                    getSchemaNodeProperties(componentsNode, result, allOfProperties, modelType, refList);
+
+                    JsonNode anyOfProperties = schemaNode.get(ANY_OF);
+                    getSchemaNodeProperties(componentsNode, result, anyOfProperties, modelType, refList);
+
+                    JsonNode oneOfProperties = schemaNode.get(ONE_OF);
+                    getSchemaNodeProperties(componentsNode, result, oneOfProperties, modelType, refList);
 
                     break;
                 }
@@ -204,11 +211,14 @@ public abstract class CommonSchemaResolver implements SchemaResolver {
         if (property.has(PROPERTIES_FIELD_NAME)) {
             fieldName = PROPERTIES_FIELD_NAME;
         }
-        if (property.has(ALL_OF_FIELD_NAME)) {
-            fieldName = ALL_OF_FIELD_NAME;
+        if (property.has(ALL_OF)) {
+            fieldName = ALL_OF;
         }
-        if (property.has(ANY_OF_FIELD_NAME)) {
-            fieldName = ANY_OF_FIELD_NAME;
+        if (property.has(ANY_OF)) {
+            fieldName = ANY_OF;
+        }
+        if (property.has(ONE_OF)) {
+            fieldName = ONE_OF;
         }
         if (!fieldName.isEmpty()) {
             JsonNode nestedProperties = property.get(fieldName);

--- a/src/main/java/org/qubership/integration/platform/runtime/catalog/service/schemas/SchemasConstants.java
+++ b/src/main/java/org/qubership/integration/platform/runtime/catalog/service/schemas/SchemasConstants.java
@@ -35,6 +35,9 @@ public final class SchemasConstants {
     public static final String PROPERTIES_FIELD_NAME = "properties";
     public static final String DEFINITIONS_NODE_NAME = "definitions";
     public static final String REQUIRED = "required";
+    public static final String ALL_OF = "allOf";
+    public static final String ANY_OF = "anyOf";
+    public static final String ONE_OF = "oneOf";
     public static final TextNode ARRAY_TYPE_NODE = new TextNode("array");
     public static final TextNode OBJECT_TYPE_NODE = new TextNode("object");
     public static final TextNode STRING_TYPE_NODE = new TextNode("string");

--- a/src/main/java/org/qubership/integration/platform/runtime/catalog/service/schemas/impl/ArraySchemaProcessor.java
+++ b/src/main/java/org/qubership/integration/platform/runtime/catalog/service/schemas/impl/ArraySchemaProcessor.java
@@ -95,8 +95,11 @@ public class ArraySchemaProcessor extends DefaultSchemaProcessor implements Sche
 
             ObjectNode itemsNode = objectMapper.createObjectNode();
             itemsNode.set(TYPE_NODE_NAME, coreSchema.get(TYPE_NODE_NAME));
-            itemsNode.set(PROPERTIES_FIELD_NAME, coreSchema.get(PROPERTIES_FIELD_NAME));
-            itemsNode.set(REQUIRED, coreSchema.get(REQUIRED));
+            putIfNotNull(itemsNode, PROPERTIES_FIELD_NAME, coreSchema.get(PROPERTIES_FIELD_NAME));
+            putIfNotNull(itemsNode, REQUIRED, coreSchema.get(REQUIRED));
+            putIfNotNull(itemsNode, ALL_OF, coreSchema.get(ALL_OF));
+            putIfNotNull(itemsNode, ONE_OF, coreSchema.get(ONE_OF));
+            putIfNotNull(itemsNode, ANY_OF, coreSchema.get(ANY_OF));
             ObjectNode resultSchema = objectMapper.createObjectNode();
             resultSchema.set(SCHEMA_ID_NODE_NAME, coreSchema.get(SCHEMA_ID_NODE_NAME));
             resultSchema.set(SCHEMA_HEADER_NODE_NAME, coreSchema.get(SCHEMA_HEADER_NODE_NAME));
@@ -108,5 +111,11 @@ public class ArraySchemaProcessor extends DefaultSchemaProcessor implements Sche
             log.error("Error during converting content string schema to JSON", e);
         }
         return objectMapper.createObjectNode();
+    }
+
+    private void putIfNotNull(ObjectNode node, String key, JsonNode value) {
+        if (value != null) {
+            node.set(key, value);
+        }
     }
 }


### PR DESCRIPTION
 Adjust json schema processor to work with oneOf anyOf allOf to resolve request|response shemes from openAPI specs correctly

Closes Netcracker/qubership-integration-ui/issues/405