### PR TITLE
fix: [v0.3][runtime-catalog#300] Subchains used in the idempotency tab are not exported with…

### DIFF
--- a/src/main/java/org/qubership/integration/platform/runtime/catalog/persistence/configs/repository/chain/ChainRepository.java
+++ b/src/main/java/org/qubership/integration/platform/runtime/catalog/persistence/configs/repository/chain/ChainRepository.java
@@ -99,7 +99,14 @@ public interface ChainRepository extends CommonRepository<Chain>, JpaRepository<
                              select properties -> 'chainFailureHandlerContainer' ->> 'elementId'
                              from catalog.elements
                              where chain_id in :chainsIds
-                                and type IN ('http-trigger'))"""
+                                and type IN ('http-trigger')
+                             UNION
+                             select properties -> 'idempotency' -> 'chainTriggerParameters' ->> 'triggerElementId'
+                             from catalog.elements
+                             where chain_id in :chainsIds
+                                and type IN ('http-trigger', 'async-api-trigger', 'kafka-trigger-2', 'rabbitmq-trigger-2', 'pubsub-trigger', 'jms-trigger')
+                                and (properties -> 'idempotency' ->> 'enabled')::boolean is true
+                            )"""
     )
     List<String> findSubChains(List<String> chainsIds);
 


### PR DESCRIPTION
… chain