### PR TITLE
fix: #342 Chain export started to include uuids for masked fields

### DIFF
--- a/src/main/java/org/qubership/integration/platform/runtime/catalog/model/exportimport/chain/MaskedFieldExternalEntity.java
+++ b/src/main/java/org/qubership/integration/platform/runtime/catalog/model/exportimport/chain/MaskedFieldExternalEntity.java
@@ -29,7 +29,8 @@ public class MaskedFieldExternalEntity {
     private final String id;
     private final String name;
 
-    public MaskedFieldExternalEntity(@JsonProperty("id") String id, @JsonProperty("name") String name) {
+    public MaskedFieldExternalEntity(@JsonProperty(value = "id", access = JsonProperty.Access.WRITE_ONLY) String id,
+            @JsonProperty("name") String name) {
         this.id = id;
         this.name = name;
     }

--- a/src/main/java/org/qubership/integration/platform/runtime/catalog/service/exportimport/mapper/chain/ChainExternalEntityMapper.java
+++ b/src/main/java/org/qubership/integration/platform/runtime/catalog/service/exportimport/mapper/chain/ChainExternalEntityMapper.java
@@ -17,6 +17,7 @@
 package org.qubership.integration.platform.runtime.catalog.service.exportimport.mapper.chain;
 
 import org.apache.commons.collections4.CollectionUtils;
+import org.codehaus.plexus.util.StringUtils;
 import org.qubership.integration.platform.runtime.catalog.model.exportimport.chain.*;
 import org.qubership.integration.platform.runtime.catalog.persistence.configs.entity.chain.*;
 import org.qubership.integration.platform.runtime.catalog.persistence.configs.entity.chain.element.ChainElement;
@@ -320,7 +321,9 @@ public class ChainExternalEntityMapper implements ExternalEntityMapper<Chain, Ch
     private Set<MaskedFieldExternalEntity> createMaskedFieldExternalEntities(Set<MaskedField> maskedFields) {
         return maskedFields.stream()
                 .map(maskedField -> new MaskedFieldExternalEntity(maskedField.getId(), maskedField.getName()))
-                .collect(Collectors.toSet());
+                .filter(entity -> StringUtils.isNotBlank(entity.getName()))
+                .sorted(Comparator.comparing(MaskedFieldExternalEntity::getName))
+                .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     private Map<String, ChainElement> extractAllElements(List<ChainElement> elements) {


### PR DESCRIPTION
<img width="579" height="371" alt="image" src="https://github.com/user-attachments/assets/bd779a72-fbf6-4ac2-a809-4a523bb13827" />
