### PR TITLE
fix: validate folder requests and sanitize persistence errors

### DIFF
--- a/src/main/java/org/qubership/integration/platform/runtime/catalog/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/qubership/integration/platform/runtime/catalog/exception/GlobalExceptionHandler.java
@@ -20,6 +20,7 @@ import com.github.jknack.handlebars.internal.lang3.StringUtils;
 import jakarta.persistence.EntityExistsException;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.ServerErrorMessage;
 import org.qubership.integration.platform.runtime.catalog.consul.exception.ConsulException;
@@ -61,8 +62,11 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 @ControllerAdvice
+@Slf4j
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     private static final String NO_STACKTRACE_AVAILABLE_MESSAGE = "No Stacktrace Available, check the logs for more details";
+    private static final String GENERIC_DATA_INTEGRITY_ERROR_MESSAGE =
+            "Invalid request content. One or more fields violate data constraints.";
 
     @ExceptionHandler
     public ResponseEntity<ExceptionDTO> handleGeneralException(Exception exception) {
@@ -257,7 +261,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
                 ));
             }
         }
-        return handleGeneralException(exception);
+        return sanitizedBadRequestResponse(GENERIC_DATA_INTEGRITY_ERROR_MESSAGE, exception);
     }
 
     @ExceptionHandler(EmptyVariableFieldException.class)
@@ -310,6 +314,15 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
                 .errorDate(new Timestamp(System.currentTimeMillis()).toString())
                 .details(details)
                 .build();
+    }
+
+    private ResponseEntity<ExceptionDTO> sanitizedBadRequestResponse(String message, Exception exception) {
+        log.warn("Request rejected: {}", message, exception);
+        ExceptionDTO exceptionDTO = ExceptionDTO.builder()
+                .errorMessage(message)
+                .errorDate(new Timestamp(System.currentTimeMillis()).toString())
+                .build();
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(exceptionDTO);
     }
 
     private String extractConstraintMessage(org.hibernate.exception.ConstraintViolationException exception) {

--- a/src/main/java/org/qubership/integration/platform/runtime/catalog/rest/v1/controller/FolderController.java
+++ b/src/main/java/org/qubership/integration/platform/runtime/catalog/rest/v1/controller/FolderController.java
@@ -19,6 +19,7 @@ package org.qubership.integration.platform.runtime.catalog.rest.v1.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.qubership.integration.platform.runtime.catalog.exception.exceptions.FolderMoveException;
@@ -161,7 +162,7 @@ public class FolderController {
 
     @PostMapping
     @Operation(description = "Create a new folder")
-    public ResponseEntity<FolderResponse> create(@RequestBody @Parameter(description = "Folder creation request object") FolderItemRequest request) {
+    public ResponseEntity<FolderResponse> create(@Valid @RequestBody @Parameter(description = "Folder creation request object") FolderItemRequest request) {
         log.info("Request to create new folder");
         var parentFolderId = request.getParentId();
         var folder = folderMapper.asEntity(request);
@@ -225,7 +226,7 @@ public class FolderController {
     @PutMapping("/{folderId}")
     @Operation(description = "Update specified folder")
     public ResponseEntity<FolderResponse> update(@PathVariable @Parameter(description = "Folder id") String folderId,
-                                                 @RequestBody @Parameter(description = "Folder modification request object") FolderItemRequest request) {
+                                                 @Valid @RequestBody @Parameter(description = "Folder modification request object") FolderItemRequest request) {
         log.info("Request to update folder with id: {}", folderId);
         var parentFolderId = request.getParentId();
         var folder = folderMapper.asEntity(request);

--- a/src/main/java/org/qubership/integration/platform/runtime/catalog/rest/v1/dto/folder/FolderItemRequest.java
+++ b/src/main/java/org/qubership/integration/platform/runtime/catalog/rest/v1/dto/folder/FolderItemRequest.java
@@ -17,6 +17,8 @@
 package org.qubership.integration.platform.runtime.catalog.rest.v1.dto.folder;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -26,12 +28,16 @@ import lombok.Setter;
 public class FolderItemRequest {
 
     @Schema(description = "Folder name")
+    @NotBlank
+    @Size(max = 255)
     private String name;
 
     @Schema(description = "Folder description")
+    @Size(max = 255)
     private String description;
 
     @Schema(description = "Parent folder id (if any)")
+    @Size(max = 255)
     private String parentId;
 
 }

--- a/src/main/java/org/qubership/integration/platform/runtime/catalog/rest/v2/controller/FolderControllerV2.java
+++ b/src/main/java/org/qubership/integration/platform/runtime/catalog/rest/v2/controller/FolderControllerV2.java
@@ -3,6 +3,7 @@ package org.qubership.integration.platform.runtime.catalog.rest.v2.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.qubership.integration.platform.runtime.catalog.exception.exceptions.FolderMoveException;
 import org.qubership.integration.platform.runtime.catalog.persistence.configs.entity.chain.Chain;
@@ -48,7 +49,7 @@ public class FolderControllerV2 {
     @PostMapping
     @Operation(description = "Create a new folder")
     public ResponseEntity<FolderItem> create(
-            @RequestBody
+            @Valid @RequestBody
             @Parameter(description = "Folder creation request object")
             CreateFolderRequest request
     ) {
@@ -110,7 +111,7 @@ public class FolderControllerV2 {
             @Parameter(description = "Folder ID")
             String id,
 
-            @RequestBody
+            @Valid @RequestBody
             @Parameter(description = "Folder update request object")
             UpdateFolderRequest request
     ) {

--- a/src/main/java/org/qubership/integration/platform/runtime/catalog/rest/v2/dto/AbstractFolderWriteRequest.java
+++ b/src/main/java/org/qubership/integration/platform/runtime/catalog/rest/v2/dto/AbstractFolderWriteRequest.java
@@ -1,0 +1,29 @@
+package org.qubership.integration.platform.runtime.catalog.rest.v2.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Setter
+@SuperBuilder
+@NoArgsConstructor
+public abstract class AbstractFolderWriteRequest {
+
+    @Schema(description = "Parent folder ID")
+    @Size(max = 255)
+    String parentId;
+
+    @Schema(description = "Name")
+    @NotBlank
+    @Size(max = 255)
+    String name;
+
+    @Schema(description = "Description")
+    @Size(max = 255)
+    String description;
+}

--- a/src/main/java/org/qubership/integration/platform/runtime/catalog/rest/v2/dto/CreateFolderRequest.java
+++ b/src/main/java/org/qubership/integration/platform/runtime/catalog/rest/v2/dto/CreateFolderRequest.java
@@ -1,6 +1,8 @@
 package org.qubership.integration.platform.runtime.catalog.rest.v2.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -16,11 +18,15 @@ public class CreateFolderRequest {
     String id;
 
     @Schema(description = "Parent folder ID")
+    @Size(max = 255)
     String parentId;
 
     @Schema(description = "Name")
+    @NotBlank
+    @Size(max = 255)
     String name;
 
     @Schema(description = "Description")
+    @Size(max = 255)
     String description;
 }

--- a/src/main/java/org/qubership/integration/platform/runtime/catalog/rest/v2/dto/CreateFolderRequest.java
+++ b/src/main/java/org/qubership/integration/platform/runtime/catalog/rest/v2/dto/CreateFolderRequest.java
@@ -1,8 +1,6 @@
 package org.qubership.integration.platform.runtime.catalog.rest.v2.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -13,20 +11,8 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder
 @NoArgsConstructor
 @Schema(description = "Create folder request object")
-public class CreateFolderRequest {
+public class CreateFolderRequest extends AbstractFolderWriteRequest {
+
     @Schema(description = "Folder ID")
     String id;
-
-    @Schema(description = "Parent folder ID")
-    @Size(max = 255)
-    String parentId;
-
-    @Schema(description = "Name")
-    @NotBlank
-    @Size(max = 255)
-    String name;
-
-    @Schema(description = "Description")
-    @Size(max = 255)
-    String description;
 }

--- a/src/main/java/org/qubership/integration/platform/runtime/catalog/rest/v2/dto/UpdateFolderRequest.java
+++ b/src/main/java/org/qubership/integration/platform/runtime/catalog/rest/v2/dto/UpdateFolderRequest.java
@@ -1,8 +1,6 @@
 package org.qubership.integration.platform.runtime.catalog.rest.v2.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -12,18 +10,6 @@ import lombok.experimental.SuperBuilder;
 @Setter
 @SuperBuilder
 @NoArgsConstructor
-@Schema(description = "Create folder request object")
-public class UpdateFolderRequest {
-    @Schema(description = "Parent folder ID")
-    @Size(max = 255)
-    String parentId;
-
-    @Schema(description = "Name")
-    @NotBlank
-    @Size(max = 255)
-    String name;
-
-    @Schema(description = "Description")
-    @Size(max = 255)
-    String description;
+@Schema(description = "Update folder request object")
+public class UpdateFolderRequest extends AbstractFolderWriteRequest {
 }

--- a/src/main/java/org/qubership/integration/platform/runtime/catalog/rest/v2/dto/UpdateFolderRequest.java
+++ b/src/main/java/org/qubership/integration/platform/runtime/catalog/rest/v2/dto/UpdateFolderRequest.java
@@ -1,6 +1,8 @@
 package org.qubership.integration.platform.runtime.catalog.rest.v2.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -13,11 +15,15 @@ import lombok.experimental.SuperBuilder;
 @Schema(description = "Create folder request object")
 public class UpdateFolderRequest {
     @Schema(description = "Parent folder ID")
+    @Size(max = 255)
     String parentId;
 
     @Schema(description = "Name")
+    @NotBlank
+    @Size(max = 255)
     String name;
 
     @Schema(description = "Description")
+    @Size(max = 255)
     String description;
 }


### PR DESCRIPTION
- Add bean validation to folder create/update DTOs and enable `@Valid` in controllers.
- Prevent SQL leakage by returning sanitized responses for `DataIntegrityViolationException`.